### PR TITLE
Tweaks to the docs!

### DIFF
--- a/src/KnpRad/views/Overview/features/application_bundle.html.twig
+++ b/src/KnpRad/views/Overview/features/application_bundle.html.twig
@@ -57,35 +57,35 @@
 
     <div style="float:right;width:58%;">
     <p>
-        RAD organizes and treats application differently compared to 3-rd party
-        bundles.
+        Instead of having many bundles that house your application code,
+        RAD creates a single, "application" bundle for your code. This bundle
+        is special compared to 3rd party bundles.
     </p>
 
     <ol>
-        <li><code>Controller</code> holds all your controllers. All of them are available through the <code>App:CONTROLLER:ACTION</code> syntax.</li>
+        <li><code>Controller</code> holds all your controllers. Refer to them via the shorter <code>App:CONTROLLER:ACTION</code> syntax.</li>
         <li><code>Tests</code> holds all your tests. The inner folder hierarchy should follow your project's one.</li>
-        <li><code>translations</code> holds all your translations</li>
-        <li><code>public</code> holds all your public *.css, *.js and *.png files. This folder will be copied (symlinked) by <code>assets:install</code> (without arguments) command.</p>
-        </li>
+        <li><code>translations</code> holds your translations</li>
+        <li><code>public</code> holds all your public *.css, *.js and *.png files. This folder will be copied (symlinked) by the <code>assets:install</code> (without arguments) command.</li>
         <li><code>views</code> holds your application views. All of them are available through the <code>App:SUBFOLDER:NAME.html.twig</code> syntax.</li>
     </ol>
     </div>
 
     <div class="clear"></div>
 
-    <h4>Why not default bundle structure?</h4>
+    <h4>Why don't we use the default bundle structure?</h4>
 
     <p>
-        That's mainly because <strong>you ain't gonna need it</strong>.
+        Mainly because <strong>you ain't gonna need it</strong>!
     </p>
 
     <p>
-        Bundles were invented for resusability, and to package a single feature.
+        Bundles were invented for resusability and to package a single feature.
     </p>
 
     <p>
         But experience proves that most of the time you don't reuse application specific code
-        and that you end up with a shitload of coupled, badly named bundles.
+        and that you end up with a shitload of coupled, badly-named bundles.
     </p>
 
     <p>
@@ -93,7 +93,7 @@
     </p>
 
     <p>
-        So, to answer the initial question, the main reason of using this kind of structure is to focus on <strong>project</strong>,
+        So, the main reason for this kind of structure is to focus on <strong>your project</strong>,
         and not on artificial bundled project structure.
     </p>
 

--- a/src/KnpRad/views/Overview/features/application_configuration.html.twig
+++ b/src/KnpRad/views/Overview/features/application_configuration.html.twig
@@ -14,18 +14,18 @@
     </div>
 
     <p>
-        Application <code>config</code> folder holds all your application configurations,
-        including routing and DIC. And those configurations will be autoloaded.
+        The Application <code>config</code> folder holds all your application configuration,
+        including routing and service/DIC configuration. And these files will be autoloaded!
     </p>
 
     <div class="clear"></div>
 
     <p>
-        Yup, no need to include <code>routing.yml</code> in your project
-        <code>config/routing/all.yml</code> or create extension class just to load
+        Yup, no need to include <code>routing.yml</code> inside
+        <code>config/routing/all.yml</code> or create an extension class just to load
         <code>services.yml</code> - this will be done for you, automatically, whenever you
-        create files with <code>services.yml</code> or <code>routing.yml</code> names inside
-        application <code>config</code> folder.
+        create files named <code>services.yml</code> or <code>routing.yml</code> inside
+        the application <code>config</code> folder.
     </p>
 
     <ul>

--- a/src/KnpRad/views/Overview/features/application_views.html.twig
+++ b/src/KnpRad/views/Overview/features/application_views.html.twig
@@ -2,21 +2,21 @@
     <h3 id="views">Views mapped to controller actions</h3>
 
     <p>
-        In application bundle, your views get mapped one-to-one to specific controller actions.
+        In the application bundle, your views get mapped one-to-one to specific controller actions.
         It means, that you don't need to write:
     </p>
     <pre><code>return $this-&gt;render('App:Overview:index.html.twig', array(
     'name' =&gt; $name
 ));</code></pre>
     <p>
-        anymore. Just returning context array <code>return array('name' =&gt; $name);</code> is
-        enough for RadKernel to understand what view you're refering to. It's like famous
-        <code>SensioExtraBundle</code>, but without annotations :-)
+        anymore. Just returning the context array <code>return array('name' =&gt; $name);</code> is
+        enough for RadKernel to understand what view you're referring to. It's like the famous
+        <code>SensioFrameworkExtraBundle</code>, but without annotations :-)
     </p>
     <p>
-        In order to help you feel connection between view and action even more, we've
-        made <code>Action</code> suffix of actions optionable. As a matter of fact,
-        <code>rad:generate:controller</code> command will generate actions without suffix for you.
+        In order to help you feel the connection between the view and action even more, we've
+        made the <code>Action</code> suffix of optional. As a matter of fact,
+        <code>rad:generate:controller</code> command will generate actions without the suffix for you.
     </p>
 
     <pre class="code_block"><code>/**

--- a/src/KnpRad/views/Overview/features/base_controller.html.twig
+++ b/src/KnpRad/views/Overview/features/base_controller.html.twig
@@ -1,0 +1,7 @@
+<section class="feature">
+    <h3 id="base-controller">Base Controller</h3>
+
+    <p>
+        
+    </p>
+</section>

--- a/src/KnpRad/views/Overview/features/bundles_configs.html.twig
+++ b/src/KnpRad/views/Overview/features/bundles_configs.html.twig
@@ -1,5 +1,5 @@
 <section class="feature">
-    <h3 id="bundles">Bundles configuration files</h3>
+    <h3 id="bundles">Bundle configuration files</h3>
 
     <div class="fs-container float-left">
         <ul class="fs-tree">
@@ -22,26 +22,39 @@
     </div>
 
     <p>
-        The <code>config/bundles</code> directory primary consern is to configure
-        all bundles used by the project. You can check the configurations
-        which comes with <em>RAD</em> distribution, most of configs contains very
-        detailed comments which can guide you through your most bizzare cases.
+        The <code>config/bundles</code> directory is concerned with configuring
+        all bundles used by the project. You can check the configuration files
+        which come with the <em>RAD</em> distribution: most contain very
+        detailed comments which can guide you through your more bizzare cases.
     </p>
 
     <p>
-        Secondary, there is one significant configuration file - <code>app.yml</code>.
+        Secondly, there is one special configuration file - <code>app.yml</code>.
         This is your project based (<a href="#app-bundle">application bundle</a>) configuration.
+        Anything here becomes a paramter, prefixed with <code>app.</code>.
+        For example, the following code would result in a <code>app.foo</code>
+        parameter:
     </p>
 
+    <div class="clear"></div>
+
+<pre><code># config/bundles/app.yml
+all:
+    foo: bar</code></pre>
+
     <p>
-        <a href="#bundles">Bundles</a> configuration files consists of environment sections, same
-        as <a href="#kernel">kernel configuration</a>.
+        Every <a href="#bundles">bundle</a> configuration file consists of environment sections, the same
+        as the <a href="#kernel">kernel configuration</a>.
     </p>
     
     <p>
-        In addition to that, <strong>KnpRadBundle</strong> will generate configuration files
-        with sensible defaults for you after calling <code>bin/vendors</code> or
-        <code>bin/configs</code> commands. for most used bundles out of the box.
+        In addition to that, the <strong>KnpRadBundle</strong> will generate configuration files
+        with sensible defaults for you after calling the <code>bin/vendors</code> or
+        <code>bin/configs</code> commands. This works for the most-used
+        bundles out of the box. In other words, after installing a new bundle
+        and running <code>bin/vendors</code>, you'll automatically have a
+        new configuration file for that bundle. If it's a well-supported bundle,
+        you'll aready have some sensible default configuration. Woh!
     </p>
 
     <div style="clear:both"></div>

--- a/src/KnpRad/views/Overview/features/code_generation.html.twig
+++ b/src/KnpRad/views/Overview/features/code_generation.html.twig
@@ -1,0 +1,7 @@
+<section class="feature">
+    <h3 id="code-generation">Code Generation</h3>
+
+    <p>
+        
+    </p>
+</section>

--- a/src/KnpRad/views/Overview/features/configs_in_one_place.html.twig
+++ b/src/KnpRad/views/Overview/features/configs_in_one_place.html.twig
@@ -1,5 +1,5 @@
 <section class="feature">
-    <h3 id="config">All configs in one place</h3>
+    <h3 id="config">All your configuration in one place</h3>
 
     <div class="fs-container float-left">
         <ul class="fs-tree">
@@ -32,30 +32,36 @@
     </div>
 
     <p>
-        In <strong>RAD</strong> edition, there's no kernel class. All kernel or project
-        configuraion lives inside <code>config/kernel.yml</code> config file (read about it
-        <a href="#kernel">here</a>). Generally, it holds environment-dependant parameters,
-        project bundles list and project name.
+        In the <strong>RAD</strong> edition, there's no kernel class. Instead,
+        all your kernel or project configuraion lives inside the <code>config/kernel.yml</code>
+        file (read about it <a href="#kernel">here</a>). Generally, it holds
+        environment-dependant parameters, a list of your project's bundles,
+        and project name.
     </p>
 
     <p>
-        In addition to <a href="#kernel">kernel configuration</a>, every bundle have its
-        <a href="#bundles">own configuration file</a> too (<code>framework.yml</code> for
-        <code>FrameworkBundle</code> or even <code>fos_user.yml</code> for <code>FOSUserBundle</code>)
-        inside <code>config/bundles</code> folder.
+        Instead of a single <code>config.yml</code> file, every bundle has
+        its <a href="#bundles">own configuration file</a> (e.g. <code>framework.yml</code>
+        for the <code>FrameworkBundle</code> or even <code>fos_user.yml</code>
+        for <code>FOSUserBundle</code>). These all live inside the <code>config/bundles</code>
+        folder.
     </p>
 
     <p>
-        Last child of <code>config</code> folder is <code>routing</code> subdirectory.
-        It holds routing configuration for bundles and only for bundles. For application-wide
-        routing use project <code>routing.yml</code>, which will be <a href="app-configs">autoloaded
-        for you</a>.
+        Finally, the <code>routing</code> subdirectory works pretty much
+        like the normal <code>app/config/routing.yml</code> and <code>app/config/routing_dev.yml</code>
+        files in the Symfony2 Standard Edition. The <code>all.yml</code> file
+        is loaded in every environment and you'll use it to import routes
+        from any 3rd party bundles. But don't put <strong>your</strong> routes
+        here! Those should live inside your application bundle's <code>routing.yml</code>
+        file, which is nicely <a href="#app-configs">autoloaded for you</a>.
     </p>
 
     <div class="clear"></div>
 
     <p>
-        <a href="#kernel">Kernel</a> and <a href="#bundles">bundles</a> configuration files 
+        Customizing your app for each environment is now super easy! The
+        <a href="#kernel">kernel</a> and <a href="#bundles">bundle</a> configuration files
         consists of environment sections.
     </p>
 
@@ -66,17 +72,18 @@ prod: ~</code></pre>
 
     <p>
         The most
-        significant is <code>all</code> environment section - kernel loads it first of all
-        and its like a default to all environments.
+        significant is the <code>all</code> environment section. Any configuration
+        under this key is loaded first any every environment.
     </p>
     
     <p>
-        Other sections should be adjusted for your environmental differences: <code>dev</code>,
+        Other sections should be adjusted for your specific environments: <code>dev</code>,
         <code>test</code>, <code>prod</code>.
     </p>
     
     <p>
-        This concept is proven, eye friendly and does not force you to browse more files
-        in order to lookup the specific configuration values used.
+        This concept is proven, easy on the eyes, and does not force you
+        to browse more files in order to lookup the specific configuration
+        values used.
     </p>
 </section>

--- a/src/KnpRad/views/Overview/features/kernel_config.html.twig
+++ b/src/KnpRad/views/Overview/features/kernel_config.html.twig
@@ -3,8 +3,8 @@
 
     <p>
         <code>config/kernel.yml</code> is the main configuration file for your application.
-        It defines all the bundles, that your project requires, environment-depending
-        parameters and project namespace.
+        It defines all the bundles that your project requires, environment-dependant
+        parameters and a project namespace.
     </p>
 
     <pre><code># config/kernel.yml
@@ -32,34 +32,36 @@ test:
         - Symfony\Bundle\WebProfilerBundle\WebProfilerBundle</code></pre>
 
     <p>
-        As <a href="#config">any other config in RAD edition</a>, this config is splitted by
-        environments and has 3 main configuration options:
+        As with <a href="#config">any other config in the RAD edition</a>, this file is split by
+        environment and has 3 main configuration options:
     </p>
 
     <ol>
         <li>
-            <code>project</code> defines your porject name (namespace). This could be
-            either simple project name (<code>KnpRad</code>) or fully qualified namespace
+            <code>project</code> defines your project name (namespace). This could be
+            either a simple project name (<code>KnpRad</code>) or fully qualified namespace
             (<code>Knp\Rad</code>). This option tells RadKernel where to find your
-            <a href="#app-bundle">application bundle</a>. In case of <code>KnpRad</code>,
-            your application code should live inside <code>src/KnpRad</code> folder and
-            have <code>KnpRad\</code> namespace. In case of <code>Knp\Rad</code> folder
-            would be <code>src/Knp/Rad</code> and namespace would be <code>Knp\Rad\</code>.
+            <a href="#app-bundle">application bundle</a>. In the case of <code>KnpRad</code>,
+            your application code should live inside the <code>src/KnpRad</code> folder and
+            have the <code>KnpRad\</code> namespace. In the case of <code>Knp\Rad</code>, the folder
+            would be <code>src/Knp/Rad</code> and the namespace would be <code>Knp\Rad\</code>.
         </li>
         <li>
             <code>parameters</code> defines environment-sensible project parameters, like
-            database connection or mailer configuration. It's like a good old <code>parameters.ini</code>.
+            database connection or mailer configuration. It's like the good old <code>parameters.ini</code>.
         </li>
         <li>
             <code>bundles</code> defines what bundle classes RadKernel should activate
             for each environment. Every environment could have own set of bundles, but
-            all environment will have same set of bundles, defined in <code>all</code>
+            all environment will have a common set of bundles, defined in the <code>all</code>
             environment section.
         </li>
     </ol>
     <p>
-        After loading <code>config/kernel.yml</code>, RadKernel will look for <code>config/kernel.custom.yml</code>
-        file, which should be ignored in your VCS and could redefine any parameter of initial
+        After loading <code>config/kernel.yml</code>, RadKernel will look for a <code>config/kernel.custom.yml</code>
+        file. You can use this file to redefine any parameters that are specific
+        to your machine. This is quite literally the equivalent of <code>parameters.ini</code>
+        and the file should be ignored in your version control system.
         <code>config/kernel.yml</code>:
         <pre><code># config/kernel.custom.yml
 all:

--- a/src/KnpRad/views/Overview/index.html.twig
+++ b/src/KnpRad/views/Overview/index.html.twig
@@ -4,12 +4,12 @@
     <section id="intro">
         &nbsp;
         <div class="logo">
-            <a href="/" title="KnpRadBundle" id="radbundle-logo">
+            <a href="#overview" title="KnpRadBundle" id="radbundle-logo">
                 <img src="{{ asset('bundles/app/img/logo.png') }}" alt="KnpRadBundle" width="317" height="58">
             </a>
 
             <p>
-                <a href="http://symfony.com">Symfony2</a> bundle that changes everything...
+                A <a href="http://symfony.com">Symfony2</a> bundle that changes everything...
             </p>
         </div>
     </section>
@@ -26,6 +26,8 @@
         {% include "App:Overview/features:application_configuration.html.twig" %}
         {% include "App:Overview/features:application_views.html.twig" %}
         {% include "App:Overview/features:assetic_pipeline.html.twig" %}
+        {% include "App:Overview/features:code_generation.html.twig" %}
+        {% include "App:Overview/features:base_controller.html.twig" %}
         {% include "App:Overview/features:project_structure.html.twig" %}
     </section>
 {% endblock content %}

--- a/src/KnpRad/views/Overview/overview.html.twig
+++ b/src/KnpRad/views/Overview/overview.html.twig
@@ -9,13 +9,13 @@
                 <li class="file yml">
                     kernel.yml
                     <a class="overview kernel" href="#kernel">
-                        Kernel config file instead of class
+                        A Kernel config file instead of class
                     </a>
                 </li>
                 <li class="dir">
                     bundles
                     <a class="overview bundles" href="#bundles">
-                        Bundles configuration in separate files
+                        Bundle configuration in separate files
                     </a>
                     <ul>
                         <li class="file yml">framework.yml</li>
@@ -31,10 +31,10 @@
                 <li class="dir">
                     KnpRad
                     <a class="overview app-bundle" href="#app-bundle">
-                        Single class-free application bundle for your application code
+                        A single, class-free application bundle for your code
                     </a>
                     <a class="overview resources" href="#app-bundle">
-                        No "Resources" folder. All resources live in application root
+                        No "Resources" folder: all resources live in application root
                     </a>
                     <ul>
                         <li class="dir">Controller
@@ -81,7 +81,7 @@
                                 <li class="dir">
                                     Main
                                     <ul>
-                                        <li class="file">index.html.yml</li>
+                                        <li class="file">index.html.twig</li>
                                     </ul>
                                 </li>
                             </ul>

--- a/src/KnpRad/views/layout.html.twig
+++ b/src/KnpRad/views/layout.html.twig
@@ -11,11 +11,13 @@
 
     <meta name="viewport" content="width=device-width">
     {% block stylesheets %}
+        {# This uses the "assetic pipeline" - it loads style.* from the application bundle #}
         {% stylesheets '|style' filter="cssrewrite" -%}
             <link rel="stylesheet" href="{{ asset_url }}">
         {%- endstylesheets %}
     {% endblock %}
 
+    {# This uses the "assetic pipeline" - it loads modernizr.* from vendor/assets/js/libs #}
     {% javascripts '|libs/modernizr' -%}
         <script src="{{ asset_url }}"></script>
     {%- endjavascripts %}
@@ -26,6 +28,7 @@
 {% block content %}{% endblock %}
 
 {% block javascripts %}
+    {# This uses the "assetic pipeline" - it loads script.* from the application bundle #}
     {% javascripts '|script' -%}
         <script src="{{ asset_url }}"></script>
     {% endjavascripts %}


### PR DESCRIPTION
Hi guys!

Woh, first, the "look" for the "site" is the hottness - especially the diagram on top - I'm guessing that was you @everzet, so a major congrats on that.

This PR is a lot of random things just from reading through. I've also stubbed out a few more sections (and we're probably missing other sections?), but haven't had a chance to fill anything in yet.

A few more comments to consider:
- The docs/site fail silently if you don't have sass installed, and less so if you don't have coffee script installed (or if your paths are different for each). I'm not sure how to address this, but I think it increases the barrier of entry.
- The idea of having assets in your vendor directory is going to be foreign to users. We need to make sure they know how this symlinking is going to happen _and_ that they're expected to actually commit these files to their repo, unlike everything else in this directory.
- We will need a README for both the bundle and edition - otherwise users will be lost on what to do when they get to GitHub.
- How do I get started? If I want to build a project, how? More generally, the docs might need to be a bit more tutorialized (or have a section that is a tutorial on how to get rolling). 
- The fact that there is just _one_ application bundle is not totally clear
- What else are we missing? I want to highlight more of the "shortcuts". Probably the most "different" things are covered well in the docs - like directory structure, config etc - but we should be very obvious about all of the shortcuts, generators, etc.

I think we have a little bit more work to do in order to make this something that someone can look at and immediately know what to do and how to get started, but it's an awfully great start for sure! And it's very good looking - I love not making ugly things :)

Thanks!
